### PR TITLE
adding bash package

### DIFF
--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION
 FROM node:${NODE_VERSION}
 
-RUN apk update && apk upgrade && apk add build-base gcc autoconf automake zlib-dev libpng-dev nasm
+RUN apk update && apk upgrade && apk add build-base gcc autoconf automake zlib-dev libpng-dev nasm bash
 
 EXPOSE 1337


### PR DESCRIPTION
fix #159
building of pngquant-bin seems to need it (especially in `configure` file)